### PR TITLE
Fix memory leak on deserialize issue for p2p messages.

### DIFF
--- a/p2p/message.go
+++ b/p2p/message.go
@@ -1,7 +1,20 @@
 package p2p
 
 import (
+	"fmt"
+
 	"github.com/elastos/Elastos.ELA.Utility/common"
+)
+
+const (
+	CMDSize      = 12
+	CMDOffset    = 4
+	ChecksumSize = 4
+	HeaderSize   = 24
+
+	// MaxMessagePayload is the maximum bytes a message can be regardless of other
+	// individual limits imposed by messages themselves.
+	MaxMessagePayload = (1024 * 1024 * 32) // 32MB
 )
 
 const (
@@ -18,15 +31,27 @@ const (
 	CmdPing        = "ping"
 	CmdPong        = "pong"
 	CmdMemPool     = "mempool"
+	CmdFilterAdd   = "filteradd"
+	CmdFilterClear = "filterclear"
 	CmdFilterLoad  = "filterload"
 	CmdMerkleBlock = "merkleblock"
 	CmdReject      = "reject"
+)
+
+var (
+	ErrDisconnected    = fmt.Errorf("[P2P] peer disconnected")
+	ErrInvalidHeader   = fmt.Errorf("[P2P] invalid message header")
+	ErrInvalidPayload  = fmt.Errorf("[P2P] invalid message payload")
+	ErrUnmatchedMagic  = fmt.Errorf("[P2P] unmatched magic")
+	ErrMsgSizeExceeded = fmt.Errorf("[P2P] message size exceeded")
 )
 
 // The message flying in the peer to peer network
 type Message interface {
 	// Get the message CMD parameter which is the type of this message
 	CMD() string
+	// Get the max payload size of this message
+	MaxLength() uint32
 	// A message is a serializable instance
 	common.Serializable
 }

--- a/p2p/msg/addr.go
+++ b/p2p/msg/addr.go
@@ -2,6 +2,7 @@ package msg
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 
 	"github.com/elastos/Elastos.ELA.Utility/common"
@@ -38,6 +39,20 @@ func (msg *Addr) Deserialize(reader io.Reader) error {
 		return err
 	}
 
-	msg.AddrList = make([]p2p.NetAddress, count)
-	return binary.Read(reader, binary.LittleEndian, &msg.AddrList)
+	if count > MaxAddrPerMsg {
+		return fmt.Errorf("Addr.Deserialize too many addresses"+
+			" for message [count %v, max %v]", count, MaxAddrPerMsg)
+	}
+
+	msg.AddrList = make([]p2p.NetAddress, 0, count)
+	for i := uint64(0); i < count; i++ {
+		var addr p2p.NetAddress
+		err := binary.Read(reader, binary.LittleEndian, &addr)
+		if err != nil {
+			return err
+		}
+		msg.AddrList = append(msg.AddrList, addr)
+	}
+
+	return nil
 }

--- a/p2p/msg/addr.go
+++ b/p2p/msg/addr.go
@@ -8,6 +8,8 @@ import (
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
 )
 
+const MaxAddrPerMsg = 1000
+
 type Addr struct {
 	AddrList []p2p.NetAddress
 }
@@ -20,6 +22,10 @@ func NewAddr(addresses []p2p.NetAddress) *Addr {
 
 func (msg *Addr) CMD() string {
 	return p2p.CmdAddr
+}
+
+func (msg *Addr) MaxLength() uint32 {
+	return 8 + (MaxAddrPerMsg * 42)
 }
 
 func (msg *Addr) Serialize(writer io.Writer) error {

--- a/p2p/msg/block.go
+++ b/p2p/msg/block.go
@@ -9,6 +9,8 @@ import (
 
 const MaxBlockSize = 8000000
 
+const MaxTxPerBlock = 100000
+
 type Block struct {
 	Block common.Serializable
 }

--- a/p2p/msg/block.go
+++ b/p2p/msg/block.go
@@ -7,6 +7,8 @@ import (
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
 )
 
+const MaxBlockSize = 8000000
+
 type Block struct {
 	Block common.Serializable
 }
@@ -17,6 +19,10 @@ func NewBlock(block common.Serializable) *Block {
 
 func (msg *Block) CMD() string {
 	return p2p.CmdBlock
+}
+
+func (msg *Block) MaxLength() uint32 {
+	return MaxBlockSize
 }
 
 func (msg *Block) Serialize(writer io.Writer) error {

--- a/p2p/msg/filteradd.go
+++ b/p2p/msg/filteradd.go
@@ -1,0 +1,40 @@
+package msg
+
+import (
+	"io"
+
+	"github.com/elastos/Elastos.ELA.Utility/p2p"
+	"github.com/elastos/Elastos.ELA.Utility/common"
+)
+
+const (
+	// MaxFilterAddDataSize is the maximum byte size of a data
+	// element to add to the Bloom filter.  It is equal to the
+	// maximum element size of a script.
+	MaxFilterAddDataSize = 520
+)
+
+type FilterAdd struct {
+	Data []byte
+}
+
+func (msg *FilterAdd) CMD() string {
+	return p2p.CmdFilterAdd
+}
+
+func (msg *FilterAdd) MaxLength() uint32 {
+	return 9 + MaxFilterAddDataSize
+}
+
+func (msg *FilterAdd) Serialize(writer io.Writer) error {
+	return common.WriteVarBytes(writer, msg.Data)
+}
+
+func (msg *FilterAdd) Deserialize(reader io.Reader) error {
+	var err error
+	msg.Data, err = common.ReadVarBytes(reader)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/p2p/msg/filterclear.go
+++ b/p2p/msg/filterclear.go
@@ -1,0 +1,26 @@
+package msg
+
+import (
+	"io"
+
+	"github.com/elastos/Elastos.ELA.Utility/p2p"
+)
+
+type FilterClear struct {
+}
+
+func (msg *FilterClear) CMD() string {
+	return p2p.CmdFilterClear
+}
+
+func (msg *FilterClear) MaxLength() uint32 {
+	return 0
+}
+
+func (msg *FilterClear) Serialize(writer io.Writer) error {
+	return nil
+}
+
+func (msg *FilterClear) Deserialize(reader io.Reader) error {
+	return nil
+}

--- a/p2p/msg/filterload.go
+++ b/p2p/msg/filterload.go
@@ -5,6 +5,16 @@ import (
 
 	"github.com/elastos/Elastos.ELA.Utility/common"
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
+	"fmt"
+)
+
+const (
+	// MaxFilterLoadHashFuncs is the maximum number of hash functions to
+	// load into the Bloom filter.
+	MaxFilterLoadHashFuncs = 50
+
+	// MaxFilterLoadFilterSize is the maximum size in bytes a filter may be.
+	MaxFilterLoadFilterSize = 36000
 )
 
 type FilterLoad struct {
@@ -17,10 +27,29 @@ func (msg *FilterLoad) CMD() string {
 	return p2p.CmdFilterLoad
 }
 
+func (msg *FilterLoad) MaxLength() uint32 {
+	return 3 + MaxFilterLoadFilterSize + 8
+}
+
 func (msg *FilterLoad) Serialize(writer io.Writer) error {
+	if msg.HashFuncs > MaxFilterLoadHashFuncs {
+		return fmt.Errorf("too many filter hash functions for message "+
+			"[count %v, max %v]", msg.HashFuncs, MaxFilterLoadHashFuncs)
+	}
+
 	return common.WriteElements(writer, msg.Filter, msg.HashFuncs, msg.Tweak)
 }
 
 func (msg *FilterLoad) Deserialize(reader io.Reader) error {
-	return common.ReadElements(reader, &msg.Filter, &msg.HashFuncs, &msg.Tweak)
+	err :=  common.ReadElements(reader, &msg.Filter, &msg.HashFuncs, &msg.Tweak)
+	if err != nil {
+		return err
+	}
+
+	if msg.HashFuncs > MaxFilterLoadHashFuncs {
+		return fmt.Errorf("too many filter hash functions for message "+
+			"[count %v, max %v]", msg.HashFuncs, MaxFilterLoadHashFuncs)
+	}
+
+	return nil
 }

--- a/p2p/msg/getaddr.go
+++ b/p2p/msg/getaddr.go
@@ -12,6 +12,10 @@ func (msg *GetAddr) CMD() string {
 	return p2p.CmdGetAddr
 }
 
+func (msg *GetAddr) MaxLength() uint32 {
+	return 0
+}
+
 func (msg *GetAddr) Serialize(io.Writer) error {
 	return nil
 }

--- a/p2p/msg/getblocks.go
+++ b/p2p/msg/getblocks.go
@@ -7,6 +7,10 @@ import (
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
 )
 
+// MaxBlockLocatorsPerMsg is the maximum number of block locator hashes allowed
+// per message.
+const MaxBlockLocatorsPerMsg = 500
+
 type GetBlocks struct {
 	Locator  []*Uint256
 	HashStop Uint256
@@ -21,6 +25,10 @@ func NewGetBlocks(locator []*Uint256, hashStop Uint256) *GetBlocks {
 
 func (msg *GetBlocks) CMD() string {
 	return p2p.CmdGetBlocks
+}
+
+func (msg *GetBlocks) MaxLength() uint32 {
+	return 4 + (MaxBlockLocatorsPerMsg * UINT256SIZE) + UINT256SIZE
 }
 
 func (msg *GetBlocks) Serialize(writer io.Writer) error {

--- a/p2p/msg/getblocks.go
+++ b/p2p/msg/getblocks.go
@@ -1,9 +1,10 @@
 package msg
 
 import (
+	"fmt"
 	"io"
 
-	. "github.com/elastos/Elastos.ELA.Utility/common"
+	"github.com/elastos/Elastos.ELA.Utility/common"
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
 )
 
@@ -12,11 +13,11 @@ import (
 const MaxBlockLocatorsPerMsg = 500
 
 type GetBlocks struct {
-	Locator  []*Uint256
-	HashStop Uint256
+	Locator  []*common.Uint256
+	HashStop common.Uint256
 }
 
-func NewGetBlocks(locator []*Uint256, hashStop Uint256) *GetBlocks {
+func NewGetBlocks(locator []*common.Uint256, hashStop common.Uint256) *GetBlocks {
 	msg := new(GetBlocks)
 	msg.Locator = locator
 	msg.HashStop = hashStop
@@ -28,19 +29,31 @@ func (msg *GetBlocks) CMD() string {
 }
 
 func (msg *GetBlocks) MaxLength() uint32 {
-	return 4 + (MaxBlockLocatorsPerMsg * UINT256SIZE) + UINT256SIZE
+	return 4 + (MaxBlockLocatorsPerMsg * common.UINT256SIZE) + common.UINT256SIZE
 }
 
 func (msg *GetBlocks) Serialize(writer io.Writer) error {
-	return WriteElements(writer, uint32(len(msg.Locator)), msg.Locator, msg.HashStop)
+	return common.WriteElements(writer, uint32(len(msg.Locator)), msg.Locator, msg.HashStop)
 }
 
 func (msg *GetBlocks) Deserialize(reader io.Reader) error {
-	count, err := ReadUint32(reader)
+	count, err := common.ReadUint32(reader)
 	if err != nil {
 		return err
 	}
+	if count > MaxBlockLocatorsPerMsg {
+		return fmt.Errorf("GetBlocks.Deserialize too many block locator"+
+			" hashes for message [count %v, max %v]", count, MaxBlockLocatorsPerMsg)
+	}
 
-	msg.Locator = make([]*Uint256, count)
-	return ReadElements(reader, &msg.Locator, &msg.HashStop)
+	msg.Locator = make([]*common.Uint256, 0, count)
+	for i := uint32(0); i < count; i++ {
+		var hash common.Uint256
+		if err := hash.Deserialize(reader); err != nil {
+			return err
+		}
+		msg.Locator = append(msg.Locator, &hash)
+	}
+
+	return msg.HashStop.Deserialize(reader)
 }

--- a/p2p/msg/getdata.go
+++ b/p2p/msg/getdata.go
@@ -33,9 +33,13 @@ func (msg *GetData) CMD() string {
 	return p2p.CmdGetData
 }
 
+func (msg *GetData) MaxLength() uint32 {
+	return 4 + (MaxInvPerMsg * maxInvVectPayload)
+}
+
 func (msg *GetData) Serialize(writer io.Writer) error {
 	count := uint32(len(msg.InvList))
-	if err := common.WriteElement(writer, count); err != nil {
+	if err := common.WriteUint32(writer, count); err != nil {
 		return err
 	}
 
@@ -49,8 +53,8 @@ func (msg *GetData) Serialize(writer io.Writer) error {
 }
 
 func (msg *GetData) Deserialize(reader io.Reader) error {
-	var count uint32
-	if err := common.ReadElement(reader, &count); err != nil {
+	count, err := common.ReadUint32(reader)
+	if err != nil {
 		return err
 	}
 

--- a/p2p/msg/getdata.go
+++ b/p2p/msg/getdata.go
@@ -1,71 +1,20 @@
 package msg
 
 import (
-	"fmt"
-	"io"
-
-	"github.com/elastos/Elastos.ELA.Utility/common"
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
 )
 
 type GetData struct {
-	InvList []*InvVect
+	Inventory
 }
 
 func NewGetData() *GetData {
 	msg := &GetData{
-		InvList: make([]*InvVect, 0, defaultInvListSize),
+		Inventory: *NewInventory(),
 	}
 	return msg
 }
 
-// AddInvVect adds an inventory vector to the message.
-func (msg *GetData) AddInvVect(iv *InvVect) error {
-	if len(msg.InvList)+1 > MaxInvPerMsg {
-		return fmt.Errorf("GetData.AddInvVect too many invvect in message [max %v]", MaxInvPerMsg)
-	}
-
-	msg.InvList = append(msg.InvList, iv)
-	return nil
-}
-
 func (msg *GetData) CMD() string {
 	return p2p.CmdGetData
-}
-
-func (msg *GetData) MaxLength() uint32 {
-	return 4 + (MaxInvPerMsg * maxInvVectPayload)
-}
-
-func (msg *GetData) Serialize(writer io.Writer) error {
-	count := uint32(len(msg.InvList))
-	if err := common.WriteUint32(writer, count); err != nil {
-		return err
-	}
-
-	for _, vect := range msg.InvList {
-		if err := vect.Serialize(writer); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (msg *GetData) Deserialize(reader io.Reader) error {
-	count, err := common.ReadUint32(reader)
-	if err != nil {
-		return err
-	}
-
-	msg.InvList = make([]*InvVect, 0, count)
-	for i := uint32(0); i < count; i++ {
-		vect := new(InvVect)
-		if err := vect.Deserialize(reader); err != nil {
-			return err
-		}
-		msg.InvList = append(msg.InvList, vect)
-	}
-
-	return nil
 }

--- a/p2p/msg/inventory.go
+++ b/p2p/msg/inventory.go
@@ -24,7 +24,7 @@ func NewInventory() *Inventory {
 // AddInvVect adds an inventory vector to the message.
 func (msg *Inventory) AddInvVect(iv *InvVect) error {
 	if len(msg.InvList)+1 > MaxInvPerMsg {
-		return fmt.Errorf("GetData.AddInvVect too many invvect in message [max %v]", MaxInvPerMsg)
+		return fmt.Errorf("AddInvVect too many invvect in message [max %v]", MaxInvPerMsg)
 	}
 
 	msg.InvList = append(msg.InvList, iv)
@@ -57,6 +57,10 @@ func (msg *Inventory) Deserialize(reader io.Reader) error {
 	count, err := common.ReadUint32(reader)
 	if err != nil {
 		return err
+	}
+	// Limit to max inventory vectors per message.
+	if count > MaxInvPerMsg {
+		return fmt.Errorf("too many invvect in message [%v]", count)
 	}
 
 	msg.InvList = make([]*InvVect, 0, count)

--- a/p2p/msg/inventory.go
+++ b/p2p/msg/inventory.go
@@ -35,9 +35,12 @@ func (msg *Inventory) CMD() string {
 	return p2p.CmdInv
 }
 
+func (msg *Inventory) MaxLength() uint32 {
+	return 4 + (MaxInvPerMsg * maxInvVectPayload)
+}
+
 func (msg *Inventory) Serialize(writer io.Writer) error {
-	count := uint32(len(msg.InvList))
-	if err := common.WriteElement(writer, count); err != nil {
+	if err := common.WriteUint32(writer, uint32(len(msg.InvList))); err != nil {
 		return err
 	}
 
@@ -51,8 +54,8 @@ func (msg *Inventory) Serialize(writer io.Writer) error {
 }
 
 func (msg *Inventory) Deserialize(reader io.Reader) error {
-	var count uint32
-	if err := common.ReadElement(reader, &count); err != nil {
+	count, err := common.ReadUint32(reader)
+	if err != nil {
 		return err
 	}
 

--- a/p2p/msg/mempool.go
+++ b/p2p/msg/mempool.go
@@ -12,6 +12,10 @@ func (msg *MemPool) CMD() string {
 	return p2p.CmdMemPool
 }
 
+func (msg *MemPool) MaxLength() uint32 {
+	return 0
+}
+
 func (msg *MemPool) Serialize(io.Writer) error {
 	return nil
 }

--- a/p2p/msg/merkleblock.go
+++ b/p2p/msg/merkleblock.go
@@ -22,6 +22,10 @@ func (msg *MerkleBlock) CMD() string {
 	return p2p.CmdMerkleBlock
 }
 
+func (msg *MerkleBlock) MaxLength() uint32 {
+	return MaxBlockSize
+}
+
 func (msg *MerkleBlock) Serialize(writer io.Writer) error {
 	err := msg.Header.Serialize(writer)
 	if err != nil {

--- a/p2p/msg/notfound.go
+++ b/p2p/msg/notfound.go
@@ -33,6 +33,10 @@ func (msg *NotFound) CMD() string {
 	return p2p.CmdNotFound
 }
 
+func (msg *NotFound) MaxLength() uint32 {
+	return 4 + (MaxInvPerMsg * maxInvVectPayload)
+}
+
 func (msg *NotFound) Serialize(writer io.Writer) error {
 	count := uint32(len(msg.InvList))
 	if err := common.WriteElement(writer, count); err != nil {

--- a/p2p/msg/notfound.go
+++ b/p2p/msg/notfound.go
@@ -1,71 +1,20 @@
 package msg
 
 import (
-	"fmt"
-	"io"
-
-	"github.com/elastos/Elastos.ELA.Utility/common"
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
 )
 
 type NotFound struct {
-	InvList []*InvVect
+	Inventory
 }
 
 func NewNotFound() *NotFound {
 	msg := &NotFound{
-		InvList: make([]*InvVect, 0, defaultInvListSize),
+		Inventory: *NewInventory(),
 	}
 	return msg
 }
 
-// AddInvVect adds an inventory vector to the message.
-func (msg *NotFound) AddInvVect(iv *InvVect) error {
-	if len(msg.InvList)+1 > MaxInvPerMsg {
-		return fmt.Errorf("NotFound.AddInvVect too many invvect in message [max %v]", MaxInvPerMsg)
-	}
-
-	msg.InvList = append(msg.InvList, iv)
-	return nil
-}
-
 func (msg *NotFound) CMD() string {
 	return p2p.CmdNotFound
-}
-
-func (msg *NotFound) MaxLength() uint32 {
-	return 4 + (MaxInvPerMsg * maxInvVectPayload)
-}
-
-func (msg *NotFound) Serialize(writer io.Writer) error {
-	count := uint32(len(msg.InvList))
-	if err := common.WriteElement(writer, count); err != nil {
-		return err
-	}
-
-	for _, vect := range msg.InvList {
-		if err := vect.Serialize(writer); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (msg *NotFound) Deserialize(reader io.Reader) error {
-	var count uint32
-	if err := common.ReadElement(reader, &count); err != nil {
-		return err
-	}
-
-	msg.InvList = make([]*InvVect, 0, count)
-	for i := uint32(0); i < count; i++ {
-		vect := new(InvVect)
-		if err := vect.Deserialize(reader); err != nil {
-			return err
-		}
-		msg.InvList = append(msg.InvList, vect)
-	}
-
-	return nil
 }

--- a/p2p/msg/ping.go
+++ b/p2p/msg/ping.go
@@ -21,6 +21,10 @@ func (msg *Ping) CMD() string {
 	return p2p.CmdPing
 }
 
+func (msg *Ping) MaxLength() uint32 {
+	return 8
+}
+
 func (msg *Ping) Serialize(writer io.Writer) error {
 	return binary.Write(writer, binary.LittleEndian, msg.Nonce)
 }

--- a/p2p/msg/reject.go
+++ b/p2p/msg/reject.go
@@ -76,6 +76,10 @@ func (msg *Reject) CMD() string {
 	return p2p.CmdReject
 }
 
+func (msg *Reject) MaxLength() uint32 {
+	return p2p.MaxMessagePayload
+}
+
 func (msg *Reject) Serialize(writer io.Writer) error {
 	if err := common.WriteVarString(writer, msg.Cmd); err != nil {
 		return err

--- a/p2p/msg/tx.go
+++ b/p2p/msg/tx.go
@@ -19,6 +19,10 @@ func (msg *Tx) CMD() string {
 	return p2p.CmdTx
 }
 
+func (msg *Tx) MaxLength() uint32 {
+	return MaxBlockSize
+}
+
 func (msg *Tx) Serialize(writer io.Writer) error {
 	return msg.Transaction.Serialize(writer)
 }

--- a/p2p/msg/v0/getdata.go
+++ b/p2p/msg/v0/getdata.go
@@ -19,6 +19,10 @@ func (msg *GetData) CMD() string {
 	return p2p.CmdGetData
 }
 
+func (msg *GetData) MaxLength() uint32 {
+	return common.UINT256SIZE
+}
+
 func (msg *GetData) Serialize(w io.Writer) error {
 	return common.WriteElement(w, msg.Hash)
 }

--- a/p2p/msg/v0/inventory.go
+++ b/p2p/msg/v0/inventory.go
@@ -1,6 +1,7 @@
 package v0
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/elastos/Elastos.ELA.Utility/common"
@@ -34,7 +35,19 @@ func (msg *Inv) Deserialize(r io.Reader) error {
 	if err != nil {
 		return err
 	}
+	// Limit to max inventory vectors per message.
+	if count > MaxInvPerMsg {
+		return fmt.Errorf("too many invvect in message [%v]", count)
+	}
 
-	msg.Hashes = make([]*common.Uint256, count)
-	return common.ReadElement(r, &msg.Hashes)
+	msg.Hashes = make([]*common.Uint256, 0, count)
+	for i := uint32(0); i < count; i++ {
+		var hash common.Uint256
+		if err := hash.Deserialize(r); err != nil {
+			return err
+		}
+		msg.Hashes = append(msg.Hashes, &hash)
+	}
+
+	return nil
 }

--- a/p2p/msg/v0/inventory.go
+++ b/p2p/msg/v0/inventory.go
@@ -7,6 +7,8 @@ import (
 	"github.com/elastos/Elastos.ELA.Utility/p2p"
 )
 
+const MaxInvPerMsg = 100
+
 type Inv struct {
 	Hashes []*common.Uint256
 }
@@ -17,6 +19,10 @@ func NewInv(hashes []*common.Uint256) *Inv {
 
 func (msg *Inv) CMD() string {
 	return p2p.CmdInv
+}
+
+func (msg *Inv) MaxLength() uint32 {
+	return 4 + (MaxInvPerMsg * common.UINT256SIZE)
 }
 
 func (msg *Inv) Serialize(w io.Writer) error {

--- a/p2p/msg/v0/notfound.go
+++ b/p2p/msg/v0/notfound.go
@@ -19,6 +19,10 @@ func (msg *NotFound) CMD() string {
 	return p2p.CmdNotFound
 }
 
+func (msg *NotFound) MaxLength() uint32 {
+	return common.UINT256SIZE
+}
+
 func (msg *NotFound) Serialize(w io.Writer) error {
 	return common.WriteElement(w, msg.Hash)
 }

--- a/p2p/msg/verack.go
+++ b/p2p/msg/verack.go
@@ -12,6 +12,10 @@ func (msg *VerAck) CMD() string {
 	return p2p.CmdVerAck
 }
 
+func (msg *VerAck) MaxLength() uint32 {
+	return 0
+}
+
 func (msg *VerAck) Serialize(io.Writer) error {
 	return nil
 }

--- a/p2p/msg/version.go
+++ b/p2p/msg/version.go
@@ -21,6 +21,10 @@ func (msg *Version) CMD() string {
 	return p2p.CmdVersion
 }
 
+func (msg *Version) MaxLength() uint32 {
+	return 35
+}
+
 func (msg *Version) Serialize(writer io.Writer) error {
 	return binary.Write(writer, binary.LittleEndian, msg)
 }

--- a/p2p/msghelper_test.go
+++ b/p2p/msghelper_test.go
@@ -184,7 +184,7 @@ func TestMsgHelper_Read_And_Write(t *testing.T) {
 	// no cmd
 	var body = make([]byte, 1024*8)
 	rand.Read(body)
-	header, err := buildHeader(987654321, "", body).Serialize()
+	header, err := BuildHeader(987654321, "", body).Serialize()
 	assert.NoError(t, err)
 	_, err = handler.Read(append(header, body...))
 	assert.EqualError(t, err, "[MsgHelper] make message failed unknown message type")
@@ -192,7 +192,7 @@ func TestMsgHelper_Read_And_Write(t *testing.T) {
 	assert.EqualError(t, err, "[MsgHelper] make message failed unknown message type")
 
 	// unknown cmd
-	header, err = buildHeader(987654321, "unknown", body).Serialize()
+	header, err = BuildHeader(987654321, "unknown", body).Serialize()
 	assert.NoError(t, err)
 	_, err = handler.Read(append(header, body...))
 	assert.EqualError(t, err, "[MsgHelper] make message failed unknown message type")
@@ -200,7 +200,7 @@ func TestMsgHelper_Read_And_Write(t *testing.T) {
 	assert.EqualError(t, err, "[MsgHelper] make message failed unknown message type")
 
 	// cmd too long
-	hdr := buildHeader(987654321, "", body)
+	hdr := BuildHeader(987654321, "", body)
 	for i := range hdr.CMD {
 		hdr.CMD[i] = 1
 	}
@@ -212,7 +212,7 @@ func TestMsgHelper_Read_And_Write(t *testing.T) {
 	assert.EqualError(t, err, "[MsgHelper] invalid message header")
 
 	// tamper message body
-	hdr = buildHeader(987654321, CmdVersion, body)
+	hdr = BuildHeader(987654321, CmdVersion, body)
 	header, err = hdr.Serialize()
 	assert.NoError(t, err)
 	rand.Read(body)

--- a/p2p/rw/messagerw.go
+++ b/p2p/rw/messagerw.go
@@ -1,0 +1,193 @@
+package rw
+
+import (
+	"io"
+	"fmt"
+	"bytes"
+
+	"github.com/elastos/Elastos.ELA.Utility/p2p/msg"
+	"github.com/elastos/Elastos.ELA.Utility/p2p/msg/v0"
+	"github.com/elastos/Elastos.ELA.Utility/p2p"
+)
+
+type MessageConfig struct {
+	ProtocolVersion uint32 // The P2P network protocol version
+	MakeTx          func() *msg.Tx
+	MakeBlock       func() *msg.Block
+	MakeMerkleBlock func() *msg.MerkleBlock
+}
+
+type MessageRW interface {
+	SetConfig(config MessageConfig)
+	ReadMessage(r io.Reader) (p2p.Message, error)
+	WriteMessage(w io.Writer, msg p2p.Message) error
+}
+
+func GetMesssageRW(magic uint32) MessageRW {
+	return &rw{magic: magic}
+}
+
+type rw struct {
+	magic  uint32
+	config MessageConfig
+}
+
+func (rw *rw) SetConfig(config MessageConfig) {
+	rw.config = config
+}
+
+func (rw *rw) ReadMessage(r io.Reader) (p2p.Message, error) {
+	// Read message header
+	var headerBytes [p2p.HeaderSize]byte
+	if _, err := io.ReadFull(r, headerBytes[:]); err != nil {
+		return nil, err
+	}
+
+	// Deserialize message header
+	var hdr p2p.Header
+	if err := hdr.Deserialize(headerBytes[:]); err != nil {
+		return nil, p2p.ErrInvalidHeader
+	}
+
+	// Check for messages from wrong network
+	if hdr.Magic != rw.magic {
+		return nil, p2p.ErrUnmatchedMagic
+	}
+
+	// Create struct of appropriate message type based on the command.
+	msg, err := rw.makeEmptyMessage(hdr.GetCMD())
+	if err != nil {
+		return nil, err
+	}
+
+	// Check for message length
+	if hdr.Length > msg.MaxLength() {
+		return nil, p2p.ErrMsgSizeExceeded
+	}
+
+	// Read payload
+	payload := make([]byte, hdr.Length)
+	_, err = io.ReadFull(r, payload[:])
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify checksum
+	if err := hdr.Verify(payload); err != nil {
+		return nil, p2p.ErrInvalidPayload
+	}
+
+	// Deserialize message
+	if err := msg.Deserialize(bytes.NewBuffer(payload)); err != nil {
+		return nil, fmt.Errorf("deserialize message %s failed %s", msg.CMD(), err.Error())
+	}
+
+	return msg, nil
+}
+
+func (rw *rw) WriteMessage(w io.Writer, msg p2p.Message) error {
+	// Serialize message
+	buf := new(bytes.Buffer)
+	if err := msg.Serialize(buf); err != nil {
+		return fmt.Errorf("serialize message failed %s", err.Error())
+	}
+	payload := buf.Bytes()
+
+	// Enforce maximum overall message payload.
+	if len(payload) > p2p.MaxMessagePayload {
+		return p2p.ErrMsgSizeExceeded
+	}
+
+	// Create message header
+	hdr, err := p2p.BuildHeader(rw.magic, msg.CMD(), payload).Serialize()
+	if err != nil {
+		return fmt.Errorf("serialize message header failed %s", err.Error())
+	}
+
+	// Write header
+	if _, err = w.Write(hdr); err != nil {
+		return err
+	}
+
+	// Write payload
+	_, err = w.Write(payload)
+	return err
+}
+
+func (rw *rw) makeEmptyMessage(cmd string) (p2p.Message, error) {
+	var message p2p.Message
+	switch cmd {
+	case p2p.CmdVersion:
+		message = new(msg.Version)
+
+	case p2p.CmdVerAck:
+		message = new(msg.VerAck)
+
+	case p2p.CmdGetAddr:
+		message = new(msg.GetAddr)
+
+	case p2p.CmdAddr:
+		message = new(msg.Addr)
+
+	case p2p.CmdGetBlocks:
+		message = new(msg.GetBlocks)
+
+	case p2p.CmdBlock:
+		message = rw.config.MakeBlock()
+
+	case p2p.CmdInv:
+		switch rw.config.ProtocolVersion {
+		case p2p.EIP001Version:
+			message = new(msg.Inventory)
+		default:
+			message = new(v0.Inv)
+		}
+
+	case p2p.CmdGetData:
+		switch rw.config.ProtocolVersion {
+		case p2p.EIP001Version:
+			message = new(msg.GetData)
+		default:
+			message = new(v0.GetData)
+		}
+
+	case p2p.CmdNotFound:
+		switch rw.config.ProtocolVersion {
+		case p2p.EIP001Version:
+			message = new(msg.NotFound)
+		default:
+			message = new(v0.NotFound)
+		}
+
+	case p2p.CmdTx:
+		message = rw.config.MakeTx()
+
+	case p2p.CmdPing:
+		message = new(msg.Ping)
+
+	case p2p.CmdPong:
+		message = new(msg.Pong)
+
+	case p2p.CmdMemPool:
+		message = new(msg.MemPool)
+
+	case p2p.CmdFilterAdd:
+		message = new(msg.FilterAdd)
+
+	case p2p.CmdFilterClear:
+		message = new(msg.FilterClear)
+
+	case p2p.CmdFilterLoad:
+		message = new(msg.FilterLoad)
+
+	case p2p.CmdMerkleBlock:
+		message = rw.config.MakeMerkleBlock()
+
+	case p2p.CmdReject:
+		message = new(msg.Reject)
+
+	default:
+		return nil, fmt.Errorf("unhandled command [%s]", cmd)
+	}
+	return message, nil
+}


### PR DESCRIPTION
1. Add MaxLength() method to message interface to limit message payload length for each message(DOS prevent).
2. Add FilterAdd() and FilterClear() messages.
3. Limit deserialized array length to prevent memory leak(DOS prevent).
4. Add message max length check for msghelper.go